### PR TITLE
Meson: ensure support for Muon

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ test(
   env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cases' },
 )
 
-dep_gtest = dependency('gtest', main : true, required : false, disabler : true)
+dep_gtest = dependency('gtest_main', required : false, disabler : true)
 
 foreach t : ['version', 'utils']
   test(

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ cps_config = executable(
 
 test(
   'pkg-config',
-  find_program('tests/runner.py'),
+  find_program('tests/runner.py', required : false, disabler : true),
   args: [cps_config, 'tests/cases.toml'],
   protocol : 'tap',
   env : {'CPS_PATH' : meson.current_source_dir() / 'tests' / 'cases' },

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : '0.0.1',
   license : 'MIT',
-  meson_version : '>= 1.0.0',
+  meson_version : '>= 0.64',
   default_options : ['cpp_std=c++17', 'buildtype=debugoptimized', 'warning_level=2'],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ cpp = meson.get_compiler('cpp')
 conf = configuration_data()
 conf.set_quoted('VERSION', meson.project_version())
 foreach f : ['unreachable']
-  conf.set10(f'HAVE_@f@'.to_upper(), cpp.has_function(f))
+  conf.set10('HAVE_@0@'.format(f.to_upper()), cpp.has_function(f))
 endforeach
 
 conf_h = configure_file(


### PR DESCRIPTION
[Muon](https://github.com/annacrombie/muon) is a C99 implementation of Meson designed to be easily bootstrapped via a shell script and (optionally) a pkg-config implementation. It's specific purpose is to be able to exist low in a bootstrap stack, since it requires just a C99 compiler, and should make it easier to use in environments where python isn't available.

A follow up for this is that Ubuntu 22.04 does not ship Muon in it's repos, but all later versions of Ubuntu do. Having an Image that was not ubuntu 22.04 based (Arch, for example) would alleviate this.